### PR TITLE
kx122: Allow setting bus frequency to enable faster operation

### DIFF
--- a/examples/c++/kx122.cxx
+++ b/examples/c++/kx122.cxx
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
   signal(SIGINT,sig_handler);
 
   //! [Interesting]
-  upm::KX122 sensor(0,-1,24);
+  upm::KX122 sensor(0, -1, 24, 10000);
 
   sensor.softwareReset();
   sensor.deviceInit(KX122_ODR_50,HIGH_RES,KX122_RANGE_2G);

--- a/examples/c/kx122.c
+++ b/examples/c/kx122.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
   signal(SIGINT,sig_handler);
 
   //! [Interesting]
-  kx122_context sensor = kx122_init(0,-1,24);
+  kx122_context sensor = kx122_init(0, -1, 24, 10000);
   if (!sensor)
   {
       printf("kx122_init() failed.\n");

--- a/examples/java/KX122_Example.java
+++ b/examples/java/KX122_Example.java
@@ -26,7 +26,7 @@ public class KX122_Example {
 	public static void main(String[] args) throws InterruptedException {
 		//! [Interesting]
 		// Instantiate a KX122
-		upm_kx122.KX122 kx122 = new upm_kx122.KX122(0, -1, 24);
+		upm_kx122.KX122 kx122 = new upm_kx122.KX122(0, -1, 24, 10000);
 
 		// Reset the device
 		kx122.softwareReset();

--- a/examples/javascript/kx122.js
+++ b/examples/javascript/kx122.js
@@ -25,7 +25,7 @@
 var kx122 = require("jsupm_kx122");
 
 // Instantiate a KX122
-var kx122_sensor = new kx122.KX122(0, -1, 24);
+var kx122_sensor = new kx122.KX122(0, -1, 24, 10000);
 
 // Reset the device
 kx122_sensor.softwareReset();

--- a/src/kx122/kx122.cxx
+++ b/src/kx122/kx122.cxx
@@ -32,7 +32,8 @@
 
 using namespace upm;
 
-KX122::KX122(int bus, int addr, int chip_select) : m_kx122(kx122_init(bus,addr,chip_select))
+KX122::KX122(int bus, int addr, int chip_select, int bus_frequency)
+  : m_kx122(kx122_init(bus,addr,chip_select,bus_frequency))
 {
   if(!m_kx122){
     throw std::runtime_error(std::string(__FUNCTION__) + "kx122_init() failed");

--- a/src/kx122/kx122.h
+++ b/src/kx122/kx122.h
@@ -46,8 +46,6 @@ extern "C"{
  * @include kx122.c
  */
 
-//Frequency of the SPI connection
-#define SPI_FREQUENCY 10000
 
 //Default slave addresses for the sensor
 #define KX122_DEFAULT_SLAVE_ADDR_1 0x1F
@@ -170,9 +168,10 @@ If no errors occur, the device gets initialized with default values and gets set
 @param bus I2C or SPI bus to use.
 @param addr I2C address of the sensor.
 @param chip_select Chip select pin for SPI.
+@param bus_frequency Speed of the communication bus in Hz.
 @return The device context, or NULL if an error occurs.
 */
-kx122_context kx122_init(int bus, int addr, int chip_select_pin);
+kx122_context kx122_init(int bus, int addr, int chip_select_pin, int bus_frequency);
 
 /**
 KX122 destructor

--- a/src/kx122/kx122.hpp
+++ b/src/kx122/kx122.hpp
@@ -50,9 +50,10 @@ namespace upm{
       @param bus I2C or SPI bus to use.
       @param addr I2C address of the sensor.
       @param chip_select Chip select pin for SPI.
+      @param bus_frequency Speed of the communication bus in Hz.
       @throws std::runtime_error on initialization failure.
       */
-      KX122(int bus, int addr, int chip_select);
+      KX122(int bus, int addr, int chip_select, int bus_frequency);
 
       /**
       KX122 destructor


### PR DESCRIPTION
The hardcoded frequency of 10kHz was much slower than the capacity of the device